### PR TITLE
Fix demo mode: use useFarmContext instead of useFarm

### DIFF
--- a/app/src/components/map/FarmMap.tsx
+++ b/app/src/components/map/FarmMap.tsx
@@ -12,7 +12,7 @@ import { useSatelliteTile, useAvailableTileDates } from '@/lib/hooks/useSatellit
 import { DrawingToolbar } from './DrawingToolbar'
 import { RasterTileLayer } from './RasterTileLayer'
 import type { Feature, Polygon } from 'geojson'
-import { useFarm } from '@/lib/convex/useFarm'
+import { useFarmContext } from '@/lib/farm'
 import { MapSkeleton } from '@/components/ui/loading/MapSkeleton'
 import { ErrorState } from '@/components/ui/error/ErrorState'
 import { createLogger } from '@/lib/logger'
@@ -486,7 +486,7 @@ export const FarmMap = forwardRef<FarmMapHandle, FarmMapProps>(function FarmMap(
   const lastFocusedSectionIdRef = useRef<string | null>(null)
 
   const { paddocks, sections, getPaddockById, noGrazeZones, waterSources, addPaddock, addNoGrazeZone, addWaterSource, resetCounter } = useGeometry()
-  const { farm, isLoading: isFarmLoading } = useFarm()
+  const { activeFarm: farm, isLoading: isFarmLoading } = useFarmContext()
   const farmId = farm?.id ?? null
   const farmLng = farm?.coordinates?.[0] ?? null
   const farmLat = farm?.coordinates?.[1] ?? null

--- a/app/src/lib/convex/useFarmSettings.ts
+++ b/app/src/lib/convex/useFarmSettings.ts
@@ -3,7 +3,7 @@ import { api } from '../../../convex/_generated/api'
 import { defaultSettings } from '@/data/mock/settings'
 import type { FarmSettings, MapPreferences } from '@/lib/types'
 import { mapFarmSettingsDoc, type FarmSettingsDoc } from './mappers'
-import { useFarm } from './useFarm'
+import { useFarmContext } from '@/lib/farm'
 
 interface UseFarmSettingsResult {
   farmId: string | null
@@ -15,7 +15,7 @@ interface UseFarmSettingsResult {
 }
 
 export function useFarmSettings(): UseFarmSettingsResult {
-  const { farmId, isLoading: isFarmLoading } = useFarm()
+  const { activeFarmId: farmId, isLoading: isFarmLoading } = useFarmContext()
   const settingsDoc = useQuery(
     api.settings.getSettings,
     farmId ? { farmId } : 'skip'


### PR DESCRIPTION
## Summary
- FarmMap and useFarmSettings were using `useFarm()` which relies on Clerk auth context
- In demo mode, the farm ID comes from `DemoFarmProvider` via `useFarmContext()`
- This was causing the map to show a loading skeleton and "Farm ID is unavailable" errors in production demo mode

## Test plan
- [ ] Test demo mode at /demo - map should render with paddocks
- [ ] Toggle NDVI layer - should not throw "Farm ID is unavailable" error
- [ ] Verify authenticated routes still work normally

Generated with [Claude Code](https://claude.ai/claude-code)