### PR TITLE
Fix subscriptionTier schema mismatch

### DIFF
--- a/app/convex/demo.ts
+++ b/app/convex/demo.ts
@@ -567,7 +567,7 @@ async function copyFarmBaseData(
   if (sourceSettings) {
     await ctx.db.insert('farmSettings', {
       farmExternalId: demoFarmId,
-      subscriptionTier: 'professional', // Demo users get professional features
+      subscriptionTier: 'premium', // Demo users get premium features
       minNDVIThreshold: sourceSettings.minNDVIThreshold,
       minRestPeriod: sourceSettings.minRestPeriod,
       cloudCoverTolerance: sourceSettings.cloudCoverTolerance,


### PR DESCRIPTION
## Summary
- Fix demo seeding error: changed 'professional' to 'premium' to match farmSettings schema

## Test plan
- [x] Demo seeding should no longer fail with schema validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)