### PR TITLE
Redesign demo tutorial as immersive experience

### DIFF
--- a/app/convex/seedData.ts
+++ b/app/convex/seedData.ts
@@ -284,7 +284,7 @@ export const samplePaddocks = basePaddocks.map((paddock) => ({
 
 export const sampleFarm = {
   externalId: DEFAULT_FARM_EXTERNAL_ID,
-  name: 'Hillcrest Station',
+  name: 'The Other Side',
   location: '120 River Heights Drive, Columbia, Tennessee, 38401',
   totalArea: 142,
   paddockCount: samplePaddocks.length,

--- a/app/src/components/onboarding/tutorial/TutorialProvider.tsx
+++ b/app/src/components/onboarding/tutorial/TutorialProvider.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 import { TutorialContext, getTutorialCompleted, setTutorialCompleted } from './useTutorial'
 
-const TOTAL_STEPS = 5
+const TOTAL_STEPS = 11
 
 interface TutorialProviderProps {
   children: ReactNode

--- a/app/src/components/onboarding/tutorial/immersive/ImmersiveTutorialOverlay.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/ImmersiveTutorialOverlay.tsx
@@ -1,0 +1,145 @@
+import { useEffect } from 'react'
+import { useTutorial } from '../useTutorial'
+import { useBriefPanel } from '@/lib/brief'
+import { useRevealState } from './useRevealState'
+import { ImmersiveTutorialProgress } from './ImmersiveTutorialProgress'
+import { HookStep } from './steps/HookStep'
+import { GapStep } from './steps/GapStep'
+import { EvolutionStep } from './steps/EvolutionStep'
+import { BottleneckStep } from './steps/BottleneckStep'
+import { UnlockStep } from './steps/UnlockStep'
+import { MeetFarmStep } from './steps/MeetFarmStep'
+import { MorningBriefStep } from './steps/MorningBriefStep'
+import { PastureHealthStep } from './steps/PastureHealthStep'
+import { DecisionStep } from './steps/DecisionStep'
+import { TrackingStep } from './steps/TrackingStep'
+import { YourTurnStep } from './steps/YourTurnStep'
+import { cn } from '@/lib/utils'
+
+const isDevMode = import.meta.env.VITE_DEV_AUTH === 'true'
+
+export function ImmersiveTutorialOverlay() {
+  const {
+    isActive,
+    currentStep,
+    totalSteps,
+    nextStep,
+    prevStep,
+    skipTutorial,
+    completeTutorial,
+    goToStep,
+  } = useTutorial()
+  const { setBriefOpen } = useBriefPanel()
+  const { phase, overlayOpacity } = useRevealState(currentStep)
+
+  const handleComplete = () => {
+    completeTutorial()
+    setTimeout(() => setBriefOpen(true), 500)
+  }
+
+  const handleSkip = () => {
+    skipTutorial()
+    setTimeout(() => setBriefOpen(true), 300)
+  }
+
+  // Dev mode keyboard shortcuts
+  useEffect(() => {
+    if (!isDevMode || !isActive) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        if (currentStep < totalSteps - 1) nextStep()
+        else handleComplete()
+      }
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        prevStep()
+      }
+      // Number keys 0-9 to jump to steps
+      if (e.key >= '0' && e.key <= '9') {
+        e.preventDefault()
+        const step = parseInt(e.key)
+        if (step < totalSteps) goToStep(step)
+      }
+      // 'S' to skip entirely
+      if (e.key === 's' || e.key === 'S') {
+        e.preventDefault()
+        handleSkip()
+      }
+      // 'E' to jump to end (last step)
+      if (e.key === 'e' || e.key === 'E') {
+        e.preventDefault()
+        goToStep(totalSteps - 1)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isActive, currentStep, totalSteps, nextStep, prevStep, goToStep])
+
+  if (!isActive) return null
+
+  const steps = [
+    <HookStep key="hook" />,
+    <GapStep key="gap" />,
+    <EvolutionStep key="evolution" />,
+    <BottleneckStep key="bottleneck" />,
+    <UnlockStep key="unlock" />,
+    <MeetFarmStep key="meet-farm" />,
+    <MorningBriefStep key="morning-brief" />,
+    <PastureHealthStep key="pasture-health" />,
+    <DecisionStep key="decision" />,
+    <TrackingStep key="tracking" />,
+    <YourTurnStep key="your-turn" />,
+  ]
+
+  return (
+    <>
+      {/* Background overlay - fades based on phase */}
+      <div
+        className="fixed inset-0 z-[60] transition-opacity duration-500 pointer-events-none"
+        style={{ backgroundColor: `rgba(0, 0, 0, ${overlayOpacity})` }}
+      />
+
+      {/* Content container - pb-32 to avoid overlapping with navigation */}
+      <div className="fixed inset-0 z-[61] flex items-center justify-center px-8 pb-32 pt-16 overflow-y-auto">
+        {/* Step content with transition */}
+        <div className="relative w-full max-w-3xl my-auto">
+          {steps.map((step, index) => (
+            <div
+              key={index}
+              className={cn(
+                'transition-all duration-300',
+                index === currentStep
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 absolute inset-0 pointer-events-none',
+                index < currentStep ? '-translate-y-8' : 'translate-y-8'
+              )}
+            >
+              {step}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Navigation controls */}
+      <ImmersiveTutorialProgress
+        currentStep={currentStep}
+        totalSteps={totalSteps}
+        phase={phase}
+        onPrev={prevStep}
+        onNext={nextStep}
+        onSkip={handleSkip}
+        onComplete={handleComplete}
+      />
+
+      {/* Dev mode shortcuts hint */}
+      {isDevMode && (
+        <div className="fixed bottom-2 left-1/2 -translate-x-1/2 z-[63] text-center text-[10px] text-white/30">
+          Dev: arrow keys navigate | 0-9 jump | S skip | E end
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/ImmersiveTutorialProgress.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/ImmersiveTutorialProgress.tsx
@@ -1,0 +1,87 @@
+import { ChevronLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { TutorialPhase } from './useRevealState'
+
+interface ImmersiveTutorialProgressProps {
+  currentStep: number
+  totalSteps: number
+  phase: TutorialPhase
+  onPrev: () => void
+  onNext: () => void
+  onSkip: () => void
+  onComplete: () => void
+}
+
+export function ImmersiveTutorialProgress({
+  currentStep,
+  totalSteps,
+  phase,
+  onPrev,
+  onNext,
+  onSkip,
+  onComplete,
+}: ImmersiveTutorialProgressProps) {
+  const isFirstStep = currentStep === 0
+  const isLastStep = currentStep === totalSteps - 1
+
+  return (
+    <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[62] flex flex-col items-center gap-4">
+      {/* Progress dots */}
+      <div className="flex items-center gap-2">
+        {Array.from({ length: totalSteps }).map((_, index) => (
+          <div
+            key={index}
+            className={cn(
+              'w-2 h-2 rounded-full transition-all duration-300',
+              index === currentStep
+                ? 'w-6 bg-white'
+                : index < currentStep
+                  ? 'bg-white/60'
+                  : 'bg-white/30'
+            )}
+          />
+        ))}
+      </div>
+
+      {/* Navigation controls */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onSkip}
+          className={cn(
+            'text-white/70 hover:text-white hover:bg-white/10',
+            phase === 'complete' && 'invisible'
+          )}
+        >
+          Skip
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onPrev}
+            disabled={isFirstStep}
+            className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:text-white disabled:opacity-30"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+
+          <Button
+            onClick={isLastStep ? onComplete : onNext}
+            className={cn(
+              'min-w-[100px]',
+              isLastStep
+                ? 'bg-green-600 hover:bg-green-700 text-white'
+                : 'bg-white text-gray-900 hover:bg-white/90'
+            )}
+          >
+            {isLastStep ? "Let's Go" : 'Next'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/index.ts
+++ b/app/src/components/onboarding/tutorial/immersive/index.ts
@@ -1,0 +1,4 @@
+export { ImmersiveTutorialOverlay } from './ImmersiveTutorialOverlay'
+export { ImmersiveTutorialProgress } from './ImmersiveTutorialProgress'
+export { useRevealState } from './useRevealState'
+export type { TutorialPhase } from './useRevealState'

--- a/app/src/components/onboarding/tutorial/immersive/steps/BottleneckStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/BottleneckStep.tsx
@@ -1,0 +1,77 @@
+import { Brain, Footprints, HelpCircle, Clock, Route, Zap } from 'lucide-react'
+
+export function BottleneckStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <Zap className="h-5 w-5 text-amber-400" />
+          <h2 className="text-sm font-medium text-amber-400 uppercase tracking-wider">
+            The Bottleneck
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Two barriers limit how much land you can manage
+        </h1>
+      </div>
+
+      {/* Two bottlenecks side by side */}
+      <div className="grid md:grid-cols-2 gap-4">
+        {/* Decision fatigue */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-4 border border-amber-500/30">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <Brain className="h-5 w-5 text-amber-400" />
+            <span className="font-medium text-amber-400">Decision Fatigue</span>
+          </div>
+
+          <p className="text-sm text-white/70 mb-3">
+            Tracking paddock status across your farm
+          </p>
+
+          <div className="space-y-2 text-left">
+            <div className="flex items-center gap-2 text-xs text-white/60">
+              <HelpCircle className="h-3.5 w-3.5 text-amber-400/70" />
+              <span>"Which paddock is ready?"</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-white/60">
+              <Clock className="h-3.5 w-3.5 text-amber-400/70" />
+              <span>"How many rest days has P4 had?"</span>
+            </div>
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-white/10 text-center">
+            <span className="text-xs text-amber-400/80">OpenPasture solves this today</span>
+          </div>
+        </div>
+
+        {/* Labor fatigue */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-4 border border-blue-500/30">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <Footprints className="h-5 w-5 text-blue-400" />
+            <span className="font-medium text-blue-400">Labor Fatigue</span>
+          </div>
+
+          <p className="text-sm text-white/70 mb-3">
+            Physically moving animals between paddocks
+          </p>
+
+          <div className="space-y-2 text-left">
+            <div className="flex items-center gap-2 text-xs text-white/60">
+              <Route className="h-3.5 w-3.5 text-blue-400/70" />
+              <span>"Moving herd 3x per week"</span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-white/60">
+              <Clock className="h-3.5 w-3.5 text-blue-400/70" />
+              <span>"Hours spent on rotation"</span>
+            </div>
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-white/10 text-center">
+            <span className="text-xs text-blue-400/80">Geo-collars coming soon</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/DecisionStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/DecisionStep.tsx
@@ -1,0 +1,60 @@
+import { CheckCircle, PenLine } from 'lucide-react'
+
+export function DecisionStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      {/* Header with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <CheckCircle className="h-5 w-5 text-green-400" />
+          <h2 className="text-sm font-medium text-green-400 uppercase tracking-wider">
+            The Decision
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Approve or modify
+        </h1>
+
+        <p className="text-base text-white/70">
+          You're always in control. The system learns from your choices.
+        </p>
+      </div>
+
+      {/* Decision options with solid backgrounds */}
+      <div className="flex flex-col md:flex-row items-center justify-center gap-4">
+        {/* AI Recommendation */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-zinc-600 w-36">
+          <div className="text-xs text-white/50 mb-1">AI Recommends</div>
+          <div className="text-base font-bold text-green-400">East Ridge</div>
+          <div className="text-xs text-white/60">P4</div>
+        </div>
+
+        <div className="text-2xl text-white/50 hidden md:block">&rarr;</div>
+
+        {/* Options */}
+        <div className="flex gap-4">
+          <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-4 border border-green-600/50 text-center w-32">
+            <div className="w-12 h-12 rounded-full bg-green-600 flex items-center justify-center mx-auto mb-2">
+              <CheckCircle className="h-6 w-6 text-white" />
+            </div>
+            <div className="text-sm font-medium text-green-400">Approve</div>
+            <div className="text-xs text-white/50 mt-1">Move to suggested section</div>
+          </div>
+
+          <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-4 border border-blue-600/50 text-center w-32">
+            <div className="w-12 h-12 rounded-full bg-blue-600 flex items-center justify-center mx-auto mb-2">
+              <PenLine className="h-6 w-6 text-white" />
+            </div>
+            <div className="text-sm font-medium text-blue-400">Modify</div>
+            <div className="text-xs text-white/50 mt-1">Choose different or stay</div>
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm bg-black/50 backdrop-blur-sm rounded-lg px-4 py-2 inline-block">
+        <span className="text-green-400 font-medium">You know your farm best.</span> The AI gives you a starting point.
+      </p>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/EvolutionStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/EvolutionStep.tsx
@@ -1,0 +1,98 @@
+import { Check, RefreshCw } from 'lucide-react'
+
+export function EvolutionStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <RefreshCw className="h-5 w-5 text-green-400" />
+          <h2 className="text-sm font-medium text-green-400 uppercase tracking-wider">
+            The Evolution
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Rotational grazing = better land efficiency
+        </h1>
+      </div>
+
+      {/* Compact rotation diagram */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-5 border border-white/10 max-w-lg mx-auto mb-4">
+        <div className="grid grid-cols-4 gap-2">
+          {[
+            { id: 'P1', status: 'active', progress: 15 },
+            { id: 'P2', status: 'recovering', progress: 40 },
+            { id: 'P3', status: 'recovering', progress: 55 },
+            { id: 'P4', status: 'recovering', progress: 70 },
+            { id: 'P5', status: 'ready', progress: 100 },
+            { id: 'P6', status: 'ready', progress: 100 },
+            { id: 'P7', status: 'ready', progress: 100 },
+            { id: 'P8', status: 'ready', progress: 100 },
+          ].map((paddock) => {
+            const isActive = paddock.status === 'active'
+            const isRecovering = paddock.status === 'recovering'
+            const bgColor = isActive ? 'bg-green-800' : isRecovering ? 'bg-zinc-700' : 'bg-green-900'
+            const borderColor = isActive ? 'border-green-400' : 'border-zinc-600'
+            const barColor = isActive ? 'bg-red-500' : isRecovering ? 'bg-amber-500' : 'bg-green-500'
+
+            return (
+              <div
+                key={paddock.id}
+                className={`${bgColor} ${borderColor} border rounded-md p-2`}
+              >
+                <div className="text-xs text-white/80 text-center mb-1">{paddock.id}</div>
+                <div className="h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full ${barColor} rounded-full`}
+                    style={{ width: `${paddock.progress}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Legend */}
+        <div className="flex justify-center gap-4 mt-3 pt-3 border-t border-white/10 text-xs">
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full bg-red-500" />
+            <span className="text-white/50">Grazing now</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full bg-amber-500" />
+            <span className="text-white/50">Recovering</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <span className="text-white/50">Ready</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Compact benefits */}
+      <div className="grid grid-cols-3 gap-2">
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center justify-center gap-1.5 text-green-400 mb-1">
+            <Check className="h-4 w-4" />
+            <span className="font-medium text-sm">Rest Period</span>
+          </div>
+          <p className="text-xs text-white/60">Grass recovers between grazing</p>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center justify-center gap-1.5 text-green-400 mb-1">
+            <Check className="h-4 w-4" />
+            <span className="font-medium text-sm">Even Use</span>
+          </div>
+          <p className="text-xs text-white/60">All forage consumed efficiently</p>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center justify-center gap-1.5 text-green-400 mb-1">
+            <Check className="h-4 w-4" />
+            <span className="font-medium text-sm">Soil Health</span>
+          </div>
+          <p className="text-xs text-white/60">Natural fertilization</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/GapStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/GapStep.tsx
@@ -1,0 +1,71 @@
+import { AlertTriangle, TrendingDown } from 'lucide-react'
+
+export function GapStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <AlertTriangle className="h-5 w-5 text-amber-400" />
+          <h2 className="text-sm font-medium text-amber-400 uppercase tracking-wider">
+            The Gap
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Continuous grazing wastes potential
+        </h1>
+      </div>
+
+      {/* Single wide card showing the problem */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-5 border border-white/10">
+        {/* Pasture degradation visualization */}
+        <div className="flex items-center justify-center gap-8 mb-4">
+          {/* Before state - healthy */}
+          <div className="text-center">
+            <div className="text-xs text-white/50 mb-2">Year 1</div>
+            <div className="w-24 h-16 rounded-lg overflow-hidden border border-white/20">
+              <div className="w-full h-full bg-gradient-to-b from-green-500 to-green-700" />
+            </div>
+            <div className="text-xs text-green-400 mt-1">Healthy</div>
+          </div>
+
+          {/* Arrow */}
+          <TrendingDown className="h-8 w-8 text-red-400" />
+
+          {/* After state - degraded */}
+          <div className="text-center">
+            <div className="text-xs text-white/50 mb-2">Year 5</div>
+            <div className="w-24 h-16 rounded-lg overflow-hidden border border-white/20">
+              <div className="w-full h-full relative">
+                <div className="absolute inset-0 bg-gradient-to-b from-amber-700 to-amber-900" />
+                <div className="absolute top-1 left-1 w-4 h-3 rounded-sm bg-green-600/60" />
+                <div className="absolute bottom-2 right-2 w-5 h-4 rounded-sm bg-green-600/40" />
+                <div className="absolute top-3 right-4 w-3 h-3 rounded-full bg-amber-950" />
+                <div className="absolute bottom-4 left-3 w-4 h-3 rounded-full bg-amber-950" />
+              </div>
+            </div>
+            <div className="text-xs text-red-400 mt-1">Degraded</div>
+          </div>
+        </div>
+
+        {/* Impact stats in a row */}
+        <div className="flex justify-center gap-6 pt-3 border-t border-white/10">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-red-400">-40%</div>
+            <div className="text-xs text-white/50">carrying capacity</div>
+          </div>
+          <div className="w-px bg-white/10" />
+          <div className="text-center">
+            <div className="text-2xl font-bold text-amber-400">+60%</div>
+            <div className="text-xs text-white/50">feed costs</div>
+          </div>
+          <div className="w-px bg-white/10" />
+          <div className="text-center">
+            <div className="text-2xl font-bold text-orange-400">5yr</div>
+            <div className="text-xs text-white/50">to recover</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/HookStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/HookStep.tsx
@@ -1,0 +1,64 @@
+import { Leaf } from 'lucide-react'
+
+export function HookStep() {
+  return (
+    <div className="max-w-2xl mx-auto text-center text-white">
+      <div className="bg-black/70 backdrop-blur-sm rounded-2xl p-6">
+        {/* Compact grass illustration */}
+        <div className="relative h-20 mb-4 overflow-hidden">
+          <svg viewBox="0 0 400 70" className="w-full h-full" preserveAspectRatio="xMidYMax slice">
+            {[...Array(16)].map((_, i) => (
+              <path
+                key={i}
+                d={`M${25 + i * 22} 70 Q${20 + i * 22} 40 ${25 + i * 22 + (i % 3 - 1) * 4} 15`}
+                stroke="url(#grassGradient)"
+                strokeWidth="3"
+                fill="none"
+                strokeLinecap="round"
+                className="animate-pulse"
+                style={{ animationDelay: `${i * 0.1}s`, animationDuration: '3s' }}
+              />
+            ))}
+            <defs>
+              <linearGradient id="grassGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+                <stop offset="0%" stopColor="#166534" />
+                <stop offset="100%" stopColor="#4ade80" />
+              </linearGradient>
+            </defs>
+          </svg>
+        </div>
+
+        {/* Main heading */}
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <Leaf className="h-8 w-8 text-green-400" />
+          <h1 className="text-4xl md:text-5xl font-bold">
+            Grass-fed can win.
+          </h1>
+          <Leaf className="h-8 w-8 text-green-400 scale-x-[-1]" />
+        </div>
+
+        <p className="text-xl md:text-2xl text-white/80 mb-6">
+          Here's how.
+        </p>
+
+        {/* Stats teaser */}
+        <div className="flex justify-center gap-6 text-sm text-white/50">
+          <div className="flex flex-col items-center">
+            <span className="text-xl font-bold text-green-400">30%</span>
+            <span className="text-xs">more forage</span>
+          </div>
+          <div className="w-px bg-white/20" />
+          <div className="flex flex-col items-center">
+            <span className="text-xl font-bold text-green-400">50%</span>
+            <span className="text-xs">less labor</span>
+          </div>
+          <div className="w-px bg-white/20" />
+          <div className="flex flex-col items-center">
+            <span className="text-xl font-bold text-green-400">1</span>
+            <span className="text-xs">daily decision</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/MeetFarmStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/MeetFarmStep.tsx
@@ -1,0 +1,81 @@
+import { MapPin, Fence, Leaf } from 'lucide-react'
+
+export function MeetFarmStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      {/* Header with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <MapPin className="h-5 w-5 text-green-400" />
+          <h2 className="text-sm font-medium text-green-400 uppercase tracking-wider">
+            Meet the Farm
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Welcome to "The Other Side" Farm
+        </h1>
+
+        <p className="text-base text-white/70">
+          8 paddocks in various stages of recovery
+        </p>
+      </div>
+
+      {/* Farm visualization with solid background */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-4 border border-white/10 max-w-lg mx-auto mb-4">
+        <svg viewBox="0 0 340 130" className="w-full h-28">
+          {[
+            { x: 10, y: 10, w: 75, h: 35, status: 'ready', name: 'P1' },
+            { x: 95, y: 10, w: 80, h: 40, status: 'ready', name: 'P2' },
+            { x: 185, y: 10, w: 65, h: 35, status: 'almost', name: 'P3' },
+            { x: 260, y: 10, w: 70, h: 38, status: 'almost', name: 'P4' },
+            { x: 15, y: 55, w: 70, h: 35, status: 'recovering', name: 'P5' },
+            { x: 95, y: 60, w: 75, h: 38, status: 'recovering', name: 'P6' },
+            { x: 180, y: 55, w: 65, h: 40, status: 'grazed', name: 'P7' },
+            { x: 255, y: 58, w: 70, h: 38, status: 'grazed', name: 'P8' },
+          ].map((p, i) => {
+            const colors = {
+              ready: { fill: '#166534', stroke: '#22c55e', text: '#4ade80' },
+              almost: { fill: '#854d0e', stroke: '#eab308', text: '#facc15' },
+              recovering: { fill: '#9a3412', stroke: '#f97316', text: '#fb923c' },
+              grazed: { fill: '#991b1b', stroke: '#ef4444', text: '#f87171' },
+            }
+            const c = colors[p.status as keyof typeof colors]
+            return (
+              <g key={i}>
+                <rect x={p.x} y={p.y} width={p.w} height={p.h} rx="3" fill={c.fill} stroke={c.stroke} strokeWidth="1.5" opacity="0.85" />
+                <text x={p.x + p.w / 2} y={p.y + p.h / 2 + 3} textAnchor="middle" fill={c.text} fontSize="10" fontWeight="bold">{p.name}</text>
+              </g>
+            )
+          })}
+          {/* Legend */}
+          <g transform="translate(20, 105)">
+            <circle cx="5" cy="5" r="4" fill="#22c55e" /><text x="14" y="8" fill="white" fontSize="8" opacity="0.7">Ready</text>
+            <circle cx="75" cy="5" r="4" fill="#eab308" /><text x="84" y="8" fill="white" fontSize="8" opacity="0.7">Almost</text>
+            <circle cx="155" cy="5" r="4" fill="#f97316" /><text x="164" y="8" fill="white" fontSize="8" opacity="0.7">Recovering</text>
+            <circle cx="255" cy="5" r="4" fill="#ef4444" /><text x="264" y="8" fill="white" fontSize="8" opacity="0.7">Grazed</text>
+          </g>
+        </svg>
+      </div>
+
+      {/* Compact stats with solid background */}
+      <div className="grid grid-cols-3 gap-3 max-w-xs mx-auto">
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-2 border border-white/10 text-center">
+          <Fence className="h-4 w-4 text-white/40 mx-auto mb-1" />
+          <div className="text-lg font-bold">8</div>
+          <div className="text-[10px] text-white/50">Paddocks</div>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-2 border border-white/10 text-center">
+          <Leaf className="h-4 w-4 text-white/40 mx-auto mb-1" />
+          <div className="text-lg font-bold">142</div>
+          <div className="text-[10px] text-white/50">Hectares</div>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-2 border border-white/10 text-center">
+          <MapPin className="h-4 w-4 text-white/40 mx-auto mb-1" />
+          <div className="text-lg font-bold">TN</div>
+          <div className="text-[10px] text-white/50">Columbia</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/MorningBriefStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/MorningBriefStep.tsx
@@ -1,0 +1,66 @@
+import { Sun, Leaf, Calendar, Brain } from 'lucide-react'
+
+export function MorningBriefStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      {/* Header with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <Sun className="h-5 w-5 text-amber-400" />
+          <h2 className="text-sm font-medium text-amber-400 uppercase tracking-wider">
+            Morning Brief
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          One decision, every morning
+        </h1>
+
+        <p className="text-base text-white/70">
+          AI analyzes your farm and recommends which paddock to graze today.
+        </p>
+      </div>
+
+      {/* What the daily plan provides */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-5 border border-white/10">
+        <div className="grid md:grid-cols-3 gap-4 mb-4">
+          <div className="text-center">
+            <div className="w-10 h-10 rounded-full bg-green-500/20 flex items-center justify-center mx-auto mb-2">
+              <Leaf className="h-5 w-5 text-green-400" />
+            </div>
+            <div className="text-sm font-medium text-white mb-1">Best Paddock</div>
+            <div className="text-xs text-white/50">Based on NDVI satellite data</div>
+          </div>
+
+          <div className="text-center">
+            <div className="w-10 h-10 rounded-full bg-blue-500/20 flex items-center justify-center mx-auto mb-2">
+              <Calendar className="h-5 w-5 text-blue-400" />
+            </div>
+            <div className="text-sm font-medium text-white mb-1">Rest Periods</div>
+            <div className="text-xs text-white/50">Tracks days since last grazed</div>
+          </div>
+
+          <div className="text-center">
+            <div className="w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center mx-auto mb-2">
+              <Brain className="h-5 w-5 text-purple-400" />
+            </div>
+            <div className="text-sm font-medium text-white mb-1">Clear Reasoning</div>
+            <div className="text-xs text-white/50">Explains why it chose this paddock</div>
+          </div>
+        </div>
+
+        {/* Example recommendation */}
+        <div className="border-t border-white/10 pt-4">
+          <div className="text-xs text-white/40 uppercase mb-2">Example Recommendation</div>
+          <div className="bg-green-900/30 rounded-lg p-3 border border-green-700/50 max-w-xs mx-auto">
+            <div className="flex items-center justify-between mb-1">
+              <span className="font-bold text-white">East Ridge</span>
+              <span className="text-[10px] bg-green-600 text-white px-1.5 py-0.5 rounded">88% match</span>
+            </div>
+            <div className="text-xs text-white/60">Highest NDVI + 24 days rest</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/PastureHealthStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/PastureHealthStep.tsx
@@ -1,0 +1,75 @@
+import { Satellite, TrendingUp, Plus } from 'lucide-react'
+
+export function PastureHealthStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      {/* Header with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <Satellite className="h-5 w-5 text-blue-400" />
+          <h2 className="text-sm font-medium text-blue-400 uppercase tracking-wider">
+            Pasture Health
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Satellite data as a starting point
+        </h1>
+
+        <p className="text-base text-white/70">
+          NDVI measures photosynthetic activity - a proxy for grass productivity.
+        </p>
+      </div>
+
+      {/* Main content */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-5 border border-white/10">
+        {/* How it works */}
+        <div className="flex items-center justify-center gap-6 mb-4">
+          <div className="text-center">
+            <div className="text-xs text-white/50 mb-1">Satellite measures</div>
+            <div className="text-sm font-medium text-blue-400">Photosynthesis</div>
+          </div>
+          <div className="text-white/30">&rarr;</div>
+          <div className="text-center">
+            <div className="text-xs text-white/50 mb-1">We infer</div>
+            <div className="text-sm font-medium text-green-400">Grass productivity</div>
+          </div>
+          <div className="text-white/30">&rarr;</div>
+          <div className="text-center">
+            <div className="text-xs text-white/50 mb-1">AI recommends</div>
+            <div className="text-sm font-medium text-amber-400">Optimal grazing</div>
+          </div>
+        </div>
+
+        {/* NDVI gradient */}
+        <div className="mb-4">
+          <div className="h-4 rounded-lg overflow-hidden mb-1"
+            style={{ background: 'linear-gradient(to right, #7f1d1d, #dc2626, #f97316, #eab308, #84cc16, #22c55e, #15803d)' }}
+          />
+          <div className="flex justify-between text-[10px] text-white/40">
+            <span>Low activity</span>
+            <span>High activity</span>
+          </div>
+        </div>
+
+        {/* Improving over time */}
+        <div className="border-t border-white/10 pt-4 grid md:grid-cols-2 gap-3">
+          <div className="flex items-start gap-2 text-left">
+            <TrendingUp className="h-4 w-4 text-green-400 mt-0.5 shrink-0" />
+            <div>
+              <div className="text-sm text-white/80">Learns from your decisions</div>
+              <div className="text-xs text-white/50">Recommendations improve as we understand your farm</div>
+            </div>
+          </div>
+          <div className="flex items-start gap-2 text-left">
+            <Plus className="h-4 w-4 text-blue-400 mt-0.5 shrink-0" />
+            <div>
+              <div className="text-sm text-white/80">More data sources coming</div>
+              <div className="text-xs text-white/50">Soil sensors, weather, and livestock tracking</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/TrackingStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/TrackingStep.tsx
@@ -1,0 +1,97 @@
+import { History, TrendingUp, BarChart3 } from 'lucide-react'
+
+export function TrackingStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      {/* Header with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <History className="h-5 w-5 text-purple-400" />
+          <h2 className="text-sm font-medium text-purple-400 uppercase tracking-wider">
+            Tracking
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          History, patterns, analytics
+        </h1>
+
+        <p className="text-base text-white/70">
+          Every decision is logged. Watch your pasture health improve.
+        </p>
+      </div>
+
+      {/* Analytics cards with solid backgrounds */}
+      <div className="grid grid-cols-3 gap-3 max-w-2xl mx-auto">
+        {/* Grazing history */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center gap-1.5 text-purple-400 mb-2 justify-center">
+            <History className="h-4 w-4" />
+            <span className="font-medium text-xs">Log</span>
+          </div>
+          <div className="space-y-1 text-left">
+            <div className="flex items-center gap-1.5 text-[10px]">
+              <div className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+              <span className="text-white/50 w-10">Today</span>
+              <span className="text-white/70">P4</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-[10px]">
+              <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+              <span className="text-white/50 w-10">Jan 19</span>
+              <span className="text-white/70">P4</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-[10px]">
+              <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+              <span className="text-white/50 w-10">Jan 18</span>
+              <span className="text-white/70">P7</span>
+            </div>
+          </div>
+        </div>
+
+        {/* NDVI trend */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center gap-1.5 text-green-400 mb-2 justify-center">
+            <TrendingUp className="h-4 w-4" />
+            <span className="font-medium text-xs">Trend</span>
+          </div>
+          <svg viewBox="0 0 100 50" className="w-full h-12">
+            <path d="M 5 40 Q 25 38, 40 32 T 70 22 T 95 15" stroke="#22c55e" strokeWidth="2" fill="none" />
+            <circle cx="5" cy="40" r="2" fill="#22c55e" />
+            <circle cx="40" cy="32" r="2" fill="#22c55e" />
+            <circle cx="70" cy="22" r="2" fill="#22c55e" />
+            <circle cx="95" cy="15" r="2" fill="#22c55e" />
+          </svg>
+          <div className="text-[10px] text-white/50">Farm NDVI improving</div>
+        </div>
+
+        {/* Stats */}
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-white/10">
+          <div className="flex items-center gap-1.5 text-blue-400 mb-2 justify-center">
+            <BarChart3 className="h-4 w-4" />
+            <span className="font-medium text-xs">Stats</span>
+          </div>
+          <div className="space-y-1.5">
+            <div>
+              <div className="flex justify-between text-[10px] mb-0.5">
+                <span className="text-white/50">Approval</span>
+                <span className="text-green-400">82%</span>
+              </div>
+              <div className="h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+                <div className="h-full bg-green-500 rounded-full" style={{ width: '82%' }} />
+              </div>
+            </div>
+            <div>
+              <div className="flex justify-between text-[10px] mb-0.5">
+                <span className="text-white/50">Rest Days</span>
+                <span className="text-blue-400">23</span>
+              </div>
+              <div className="h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+                <div className="h-full bg-blue-500 rounded-full" style={{ width: '77%' }} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/UnlockStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/UnlockStep.tsx
@@ -1,0 +1,90 @@
+import { Satellite, Cpu, MessageSquare } from 'lucide-react'
+
+export function UnlockStep() {
+  return (
+    <div className="max-w-3xl mx-auto text-center text-white">
+      <div className="bg-black/70 backdrop-blur-sm rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <Satellite className="h-5 w-5 text-blue-400" />
+          <h2 className="text-sm font-medium text-blue-400 uppercase tracking-wider">
+            The Unlock
+          </h2>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">
+          Satellite today. Sensors + farmer inputs tomorrow.
+        </h1>
+      </div>
+
+      {/* Compact flow diagram */}
+      <div className="bg-zinc-900/95 backdrop-blur-sm rounded-xl p-4 border border-white/10 max-w-lg mx-auto mb-4">
+        <svg viewBox="0 0 420 100" className="w-full h-24">
+          {/* Satellite */}
+          <g transform="translate(40, 25)">
+            <rect x="-12" y="-4" width="24" height="16" rx="2" fill="#3b82f6" />
+            <rect x="-28" y="0" width="16" height="8" rx="1" fill="#60a5fa" />
+            <rect x="12" y="0" width="16" height="8" rx="1" fill="#60a5fa" />
+            <path d="M 0 16 L 0 40" stroke="#60a5fa" strokeWidth="2" strokeDasharray="3,3" />
+          </g>
+          <text x="40" y="80" textAnchor="middle" fill="white" fontSize="9" opacity="0.6">Satellite</text>
+
+          {/* Arrow */}
+          <path d="M 80 50 L 130 50" stroke="#4ade80" strokeWidth="2" markerEnd="url(#arr)" />
+
+          {/* AI */}
+          <g transform="translate(170, 30)">
+            <rect x="-25" y="-8" width="50" height="40" rx="6" fill="#1e1b4b" stroke="#6366f1" strokeWidth="2" />
+            <circle cx="-8" cy="5" r="3" fill="#a5b4fc" />
+            <circle cx="8" cy="5" r="3" fill="#a5b4fc" />
+            <circle cx="0" cy="16" r="3" fill="#a5b4fc" />
+            <line x1="-8" y1="5" x2="0" y2="16" stroke="#a5b4fc" />
+            <line x1="8" y1="5" x2="0" y2="16" stroke="#a5b4fc" />
+          </g>
+          <text x="170" y="80" textAnchor="middle" fill="white" fontSize="9" opacity="0.6">AI Analysis</text>
+
+          {/* Arrow */}
+          <path d="M 210 50 L 260 50" stroke="#4ade80" strokeWidth="2" markerEnd="url(#arr)" />
+
+          {/* Recommendation */}
+          <g transform="translate(310, 25)">
+            <rect x="-35" y="0" width="70" height="45" rx="4" fill="#18181b" stroke="#4ade80" strokeWidth="2" />
+            <text x="0" y="16" textAnchor="middle" fill="#4ade80" fontSize="8" fontWeight="bold">TODAY</text>
+            <text x="0" y="28" textAnchor="middle" fill="white" fontSize="9">Graze P4</text>
+            <text x="0" y="40" textAnchor="middle" fill="white" fontSize="7" opacity="0.6">East Ridge</text>
+          </g>
+
+          {/* Farmer */}
+          <g transform="translate(390, 45)">
+            <circle cx="0" cy="-8" r="8" fill="#f59e0b" />
+            <path d="M -10 15 L 0 3 L 10 15" fill="#f59e0b" />
+          </g>
+
+          <defs>
+            <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+              <polygon points="0 0, 8 3, 0 6" fill="#4ade80" />
+            </marker>
+          </defs>
+        </svg>
+      </div>
+
+      {/* Compact feature cards */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-blue-500/30">
+          <Satellite className="h-6 w-6 text-blue-400 mx-auto mb-2" />
+          <h3 className="font-medium text-sm mb-1">Satellite Data</h3>
+          <p className="text-xs text-white/60">10m NDVI every 5 days</p>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-purple-500/30">
+          <Cpu className="h-6 w-6 text-purple-400 mx-auto mb-2" />
+          <h3 className="font-medium text-sm mb-1">AI Analysis</h3>
+          <p className="text-xs text-white/60">Weighs all factors</p>
+        </div>
+        <div className="bg-zinc-900/95 backdrop-blur-sm rounded-lg p-3 border border-green-500/30">
+          <MessageSquare className="h-6 w-6 text-green-400 mx-auto mb-2" />
+          <h3 className="font-medium text-sm mb-1">You Decide</h3>
+          <p className="text-xs text-white/60">System learns from you</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/steps/YourTurnStep.tsx
+++ b/app/src/components/onboarding/tutorial/immersive/steps/YourTurnStep.tsx
@@ -1,0 +1,52 @@
+import { Sparkles, MousePointer } from 'lucide-react'
+
+export function YourTurnStep() {
+  return (
+    <div className="max-w-2xl mx-auto text-center text-white">
+      {/* Content with backdrop */}
+      <div className="bg-black/70 backdrop-blur-sm rounded-2xl p-6">
+        {/* Sparkle icon with glow */}
+        <div className="relative inline-block mb-4">
+          <div className="absolute inset-0 bg-green-500/30 rounded-full blur-xl animate-pulse" />
+          <div className="relative w-16 h-16 rounded-full bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center">
+            <Sparkles className="h-8 w-8 text-white" />
+          </div>
+        </div>
+
+        <h2 className="text-sm font-medium text-green-400 uppercase tracking-wider mb-2">
+          Your Turn
+        </h2>
+
+        <h1 className="text-3xl md:text-4xl font-bold mb-3">
+          Make today's decision
+        </h1>
+
+        <p className="text-lg text-white/70 mb-4 max-w-md mx-auto">
+          The Morning Brief will open with today's recommendation.
+        </p>
+
+        {/* Action preview */}
+        <div className="bg-zinc-900/80 rounded-xl p-4 border border-green-500/30 max-w-xs mx-auto">
+          <div className="flex items-center justify-center gap-2 mb-3 text-white/70">
+            <MousePointer className="h-4 w-4 text-green-400" />
+            <span className="text-sm">When you click "Let's Go":</span>
+          </div>
+          <div className="flex justify-center gap-6 text-sm">
+            <div className="flex items-center gap-2">
+              <div className="w-5 h-5 rounded-full bg-green-600 flex items-center justify-center text-xs font-bold">1</div>
+              <span className="text-white/80">Tutorial closes</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-5 h-5 rounded-full bg-green-600 flex items-center justify-center text-xs font-bold">2</div>
+              <span className="text-white/80">Brief opens</span>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-3 text-xs text-white/40">
+          Demo farm - experiment freely!
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/onboarding/tutorial/immersive/useRevealState.ts
+++ b/app/src/components/onboarding/tutorial/immersive/useRevealState.ts
@@ -1,0 +1,18 @@
+export type TutorialPhase = 'fullscreen' | 'reveal' | 'spotlight' | 'complete'
+
+export function useRevealState(currentStep: number) {
+  const phase: TutorialPhase =
+    currentStep < 5 ? 'fullscreen'
+    : currentStep === 5 ? 'reveal'
+    : currentStep < 10 ? 'spotlight'
+    : 'complete'
+
+  const overlayOpacity = {
+    fullscreen: 0.5,
+    reveal: 0.5,
+    spotlight: 0.5,
+    complete: 0
+  }[phase]
+
+  return { phase, overlayOpacity }
+}

--- a/app/src/components/onboarding/tutorial/index.ts
+++ b/app/src/components/onboarding/tutorial/index.ts
@@ -4,3 +4,4 @@ export { useTutorial, getTutorialCompleted, setTutorialCompleted } from './useTu
 export { ScreenshotFrame } from './ScreenshotFrame'
 export { GrassAnimation } from './GrassAnimation'
 export { TutorialProgress } from './TutorialProgress'
+export { ImmersiveTutorialOverlay } from './immersive'

--- a/app/src/routes/demo.tsx
+++ b/app/src/routes/demo.tsx
@@ -9,7 +9,8 @@ import { DemoAuthProvider, useDemoAuth } from '@/lib/auth/DemoAuthProvider'
 import { SatelliteAnimationProvider } from '@/lib/satellite-animation'
 import { SatelliteCollapseAnimation } from '@/components/layout/SatelliteCollapseAnimation'
 import { useDemoSeeding } from '@/lib/convex/useDemoSeeding'
-import { TutorialProvider, TutorialOverlay } from '@/components/onboarding/tutorial'
+import { TutorialProvider } from '@/components/onboarding/tutorial'
+import { ImmersiveTutorialOverlay } from '@/components/onboarding/tutorial/immersive'
 import { isDemoDevMode } from '@/lib/demo/isDemoDevMode'
 
 export const Route = createFileRoute('/demo')({
@@ -56,7 +57,7 @@ function DemoLayoutContent() {
                 </div>
               </div>
               <SatelliteCollapseAnimation />
-              <TutorialOverlay />
+              <ImmersiveTutorialOverlay />
             </TutorialProvider>
           </SatelliteAnimationProvider>
         </BriefPanelProvider>


### PR DESCRIPTION
## Summary

- Replace modal-based 5-step tutorial with full-screen immersive 11-step experience
- New narrative: "Grass-fed can win" - pragmatic, outcome-focused messaging
- Gradual reveal from full-screen slides to app with semi-transparent backgrounds
- Frame both decision fatigue and labor fatigue as bottlenecks (sets up geo-collar roadmap)
- Contextualize NDVI as proxy for photosynthesis, mention future data sources
- Update decision flow to Approve/Modify (removed Reject option)
- Rename demo farm from "Hillcrest Station" to "The Other Side"
- Morning Brief opens automatically after tutorial completion

## Test plan

- [ ] Navigate to `/demo` and verify tutorial auto-starts
- [ ] Click through all 11 steps, verify gradual reveal of map background
- [ ] Verify "The Other Side" farm name appears correctly
- [ ] Complete tutorial and verify Morning Brief panel opens
- [ ] Test Skip button functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)