### PR TITLE
Restructure routes from _app to app and add plan checking

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -27,6 +27,10 @@ CLERK_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 # Set to "true" to bypass Clerk auth during local development
 VITE_DEV_AUTH=false
 
+# Set to "true" to disable the subscription paywall (useful for dev)
+# Paywall is enabled by default in production
+VITE_PAYWALL_DISABLED=false
+
 # =============================================================================
 # Braintrust Observability (Optional)
 # =============================================================================

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -76,6 +76,7 @@ Domain types in `src/lib/types.ts`: `Plan`, `Paddock`, `Farm`, `Section`, `Obser
 Required for full functionality:
 - `VITE_CONVEX_URL` - Convex deployment URL
 - `VITE_CLERK_PUBLISHABLE_KEY` - Clerk auth (or use `VITE_DEV_AUTH=true` for dev mode)
+- `VITE_PAYWALL_DISABLED` - Set to "true" to disable the subscription paywall (paywall is enabled by default)
 - `BRAINTRUST_API_KEY` - Agent observability (optional, set in Convex dashboard)
 - `BRAINTRUST_PROJECT_NAME` - Braintrust project name (optional, defaults to 'grazing-agent')
 

--- a/app/src/components/analytics/RotationHeatmap.tsx
+++ b/app/src/components/analytics/RotationHeatmap.tsx
@@ -48,8 +48,8 @@ export function RotationHeatmap({
               {data.map((row) => (
                 <tr key={row.paddockId} className="border-t border-border">
                   <td className="py-2 pr-4">
-                    <Link 
-                      to="/paddocks/$id" 
+                    <Link
+                      to="/app/paddocks/$id"
                       params={{ id: row.paddockId }}
                       className="hover:underline"
                     >

--- a/app/src/components/brief/SatelliteMiniMap.tsx
+++ b/app/src/components/brief/SatelliteMiniMap.tsx
@@ -580,7 +580,7 @@ export function SatelliteMiniMap({
       {/* Edit button - links to map page with edit mode */}
       {!isEditActive && isMapLoaded && showEditButton && (
         <Link
-          to="/map"
+          to="/app/map"
           search={{
             edit: true,
             paddockId,

--- a/app/src/components/demo/DemoBanner.tsx
+++ b/app/src/components/demo/DemoBanner.tsx
@@ -50,7 +50,7 @@ export function DemoBanner() {
         </button>
 
         <Link
-          to="/onboarding"
+          to="/sign-in"
           className="flex items-center gap-1 px-2 py-0.5 rounded bg-amber-900 hover:bg-amber-800 text-white transition-colors"
         >
           <UserPlus className="h-3 w-3" />

--- a/app/src/components/demo/DemoDevToolsDropdown.tsx
+++ b/app/src/components/demo/DemoDevToolsDropdown.tsx
@@ -38,7 +38,7 @@ export function DemoDevToolsDropdown() {
   }
 
   const handleResetOnboarding = () => {
-    navigate({ to: '/onboarding' })
+    navigate({ to: '/app/onboarding' })
     toast.success('Navigating to onboarding')
   }
 

--- a/app/src/components/demo/DemoHeader.tsx
+++ b/app/src/components/demo/DemoHeader.tsx
@@ -27,7 +27,7 @@ export function DemoHeader() {
         <DemoDevToolsDropdown />
 
         <Link
-          to="/onboarding"
+          to="/sign-in"
           className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-white bg-green-600 hover:bg-green-700 rounded-md transition-colors"
         >
           Sign Up

--- a/app/src/components/demo/DemoUpsellDialog.tsx
+++ b/app/src/components/demo/DemoUpsellDialog.tsx
@@ -57,7 +57,7 @@ export function DemoUpsellDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Continue Demo
           </Button>
-          <Link to="/onboarding">
+          <Link to="/sign-in">
             <Button>Create Account</Button>
           </Link>
         </DialogFooter>

--- a/app/src/components/layout/DevToolsDropdown.tsx
+++ b/app/src/components/layout/DevToolsDropdown.tsx
@@ -36,7 +36,7 @@ export function DevToolsDropdown() {
   }
 
   const handleResetOnboarding = () => {
-    navigate({ to: '/onboarding' })
+    navigate({ to: '/app/onboarding' })
     toast.success('Navigating to onboarding')
   }
 

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -16,9 +16,9 @@ interface NavItem {
 }
 
 function getNavItems(isDemo: boolean): NavItem[] {
-  const prefix = isDemo ? '/demo' : ''
+  const prefix = isDemo ? '/demo' : '/app'
   return [
-    { label: 'GIS View', icon: Map, href: isDemo ? '/demo' : '/' },
+    { label: 'GIS View', icon: Map, href: isDemo ? '/demo' : '/app' },
     { label: 'History', icon: History, href: `${prefix}/history` },
     { label: 'Analytics', icon: BarChart3, href: `${prefix}/analytics` },
   ]
@@ -28,7 +28,7 @@ export function Sidebar() {
   const location = useLocation()
   const isDemo = location.pathname.startsWith('/demo')
   const navItems = getNavItems(isDemo)
-  const settingsPath = isDemo ? '/demo/settings' : '/settings'
+  const settingsPath = isDemo ? '/demo/settings' : '/app/settings'
 
   return (
     <TooltipProvider delayDuration={0}>

--- a/app/src/components/marketing/CTASection.tsx
+++ b/app/src/components/marketing/CTASection.tsx
@@ -23,7 +23,7 @@ export function CTASection() {
 
           <div className="flex flex-col sm:flex-row gap-3 justify-center items-center pt-2">
             <Link
-              to="/onboarding"
+              to="/sign-in"
               className="inline-flex items-center justify-center text-base px-6 py-3 rounded-md bg-[#075056] hover:bg-[#FF5B04] text-[#FDF6E3] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#075056] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a2429]"
             >
               Request Early Access

--- a/app/src/components/marketing/Footer.tsx
+++ b/app/src/components/marketing/Footer.tsx
@@ -35,7 +35,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  to="/onboarding"
+                  to="/sign-in"
                   className={`hover:text-[#FDF6E3] transition-colors ${focusRing}`}
                 >
                   Get Started

--- a/app/src/components/marketing/HeroSection.tsx
+++ b/app/src/components/marketing/HeroSection.tsx
@@ -35,7 +35,7 @@ export function HeroSection() {
             </Link>
 
             <Link
-              to="/onboarding"
+              to="/sign-in"
               className="inline-flex items-center justify-center text-sm px-5 py-2.5 rounded-md bg-[#075056] hover:bg-[#086369] text-[#FDF6E3] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#075056] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a2429]"
             >
               Join the Waitlist

--- a/app/src/components/marketing/MarketingHeader.tsx
+++ b/app/src/components/marketing/MarketingHeader.tsx
@@ -7,7 +7,7 @@ export function MarketingHeader() {
       <div className="container mx-auto px-4">
         <div className="flex h-12 items-center justify-between">
           <Link
-            to="/marketing"
+            to="/"
             className="flex items-center space-x-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#075056] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a2429]"
           >
             <span className="text-lg font-bold text-[#FDF6E3]">OpenPasture</span>
@@ -40,7 +40,7 @@ export function MarketingHeader() {
               Technology
             </Link>
             <Link
-              to="/onboarding"
+              to="/sign-in"
               className="inline-flex items-center justify-center gap-1.5 rounded-md text-xs font-medium border border-[#075056]/30 bg-transparent px-2.5 py-1.5 text-[#D3DBDD] hover:bg-[#075056]/20 hover:text-[#FDF6E3] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#075056] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a2429]"
             >
               <LogIn className="h-3.5 w-3.5" aria-hidden="true" />

--- a/app/src/components/paddock/PaddockHeader.tsx
+++ b/app/src/components/paddock/PaddockHeader.tsx
@@ -31,7 +31,7 @@ export function PaddockHeader({ paddock, onEdit }: PaddockHeaderProps) {
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link to="/map">
+          <Link to="/app/map">
             <ArrowLeft className="h-5 w-5" />
             <span className="sr-only">Back to map</span>
           </Link>

--- a/app/src/components/settings/FarmInfoStrip.tsx
+++ b/app/src/components/settings/FarmInfoStrip.tsx
@@ -12,7 +12,7 @@ export function FarmInfoStrip() {
   const { format } = useAreaUnit()
 
   const handleEditBoundary = () => {
-    navigate({ to: '/', search: { editBoundary: 'true' } })
+    navigate({ to: '/app', search: { editBoundary: 'true' } })
   }
 
   if (!farm) return null

--- a/app/src/components/settings/SettingsForm.tsx
+++ b/app/src/components/settings/SettingsForm.tsx
@@ -32,7 +32,7 @@ export function SettingsForm({ settings, onChange }: SettingsFormProps) {
   const { format } = useAreaUnit()
 
   const handleEditBoundary = () => {
-    navigate({ to: '/', search: { editBoundary: 'true' } })
+    navigate({ to: '/app', search: { editBoundary: 'true' } })
   }
 
   const updateSetting = <K extends keyof FarmSettings>(

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -12,26 +12,27 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SubscribeRouteImport } from './routes/subscribe'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as DemoRouteImport } from './routes/demo'
+import { Route as AppRouteImport } from './routes/app'
 import { Route as PublicRouteImport } from './routes/_public'
-import { Route as AppRouteImport } from './routes/_app'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoIndexRouteImport } from './routes/demo/index'
-import { Route as AppIndexRouteImport } from './routes/_app/index'
+import { Route as AppIndexRouteImport } from './routes/app/index'
 import { Route as DemoSettingsRouteImport } from './routes/demo/settings'
 import { Route as DemoHistoryRouteImport } from './routes/demo/history'
 import { Route as DemoAnalyticsRouteImport } from './routes/demo/analytics'
+import { Route as AppUpgradeRouteImport } from './routes/app/upgrade'
+import { Route as AppSettingsRouteImport } from './routes/app/settings'
+import { Route as AppOnboardingRouteImport } from './routes/app/onboarding'
+import { Route as AppMapRouteImport } from './routes/app/map'
+import { Route as AppHistoryRouteImport } from './routes/app/history'
+import { Route as AppAnalyticsRouteImport } from './routes/app/analytics'
 import { Route as PublicTechnologyRouteImport } from './routes/_public/technology'
 import { Route as PublicResearchRouteImport } from './routes/_public/research'
 import { Route as PublicMarketingRouteImport } from './routes/_public/marketing'
 import { Route as PublicInvestorsRouteImport } from './routes/_public/investors'
 import { Route as PublicDocsRouteImport } from './routes/_public/docs'
-import { Route as AppUpgradeRouteImport } from './routes/_app/upgrade'
-import { Route as AppSettingsRouteImport } from './routes/_app/settings'
-import { Route as AppOnboardingRouteImport } from './routes/_app/onboarding'
-import { Route as AppMapRouteImport } from './routes/_app/map'
-import { Route as AppHistoryRouteImport } from './routes/_app/history'
-import { Route as AppAnalyticsRouteImport } from './routes/_app/analytics'
 import { Route as PublicDocsIndexRouteImport } from './routes/_public/docs/index'
-import { Route as AppPaddocksIdRouteImport } from './routes/_app/paddocks/$id'
+import { Route as AppPaddocksIdRouteImport } from './routes/app/paddocks/$id'
 import { Route as PublicDocsCategoryArticleRouteImport } from './routes/_public/docs/$category.$article'
 
 const SubscribeRoute = SubscribeRouteImport.update({
@@ -49,12 +50,18 @@ const DemoRoute = DemoRouteImport.update({
   path: '/demo',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AppRoute = AppRouteImport.update({
+  id: '/app',
+  path: '/app',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PublicRoute = PublicRouteImport.update({
   id: '/_public',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppRoute = AppRouteImport.update({
-  id: '/_app',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DemoIndexRoute = DemoIndexRouteImport.update({
@@ -81,31 +88,6 @@ const DemoAnalyticsRoute = DemoAnalyticsRouteImport.update({
   id: '/analytics',
   path: '/analytics',
   getParentRoute: () => DemoRoute,
-} as any)
-const PublicTechnologyRoute = PublicTechnologyRouteImport.update({
-  id: '/technology',
-  path: '/technology',
-  getParentRoute: () => PublicRoute,
-} as any)
-const PublicResearchRoute = PublicResearchRouteImport.update({
-  id: '/research',
-  path: '/research',
-  getParentRoute: () => PublicRoute,
-} as any)
-const PublicMarketingRoute = PublicMarketingRouteImport.update({
-  id: '/marketing',
-  path: '/marketing',
-  getParentRoute: () => PublicRoute,
-} as any)
-const PublicInvestorsRoute = PublicInvestorsRouteImport.update({
-  id: '/investors',
-  path: '/investors',
-  getParentRoute: () => PublicRoute,
-} as any)
-const PublicDocsRoute = PublicDocsRouteImport.update({
-  id: '/docs',
-  path: '/docs',
-  getParentRoute: () => PublicRoute,
 } as any)
 const AppUpgradeRoute = AppUpgradeRouteImport.update({
   id: '/upgrade',
@@ -137,6 +119,31 @@ const AppAnalyticsRoute = AppAnalyticsRouteImport.update({
   path: '/analytics',
   getParentRoute: () => AppRoute,
 } as any)
+const PublicTechnologyRoute = PublicTechnologyRouteImport.update({
+  id: '/technology',
+  path: '/technology',
+  getParentRoute: () => PublicRoute,
+} as any)
+const PublicResearchRoute = PublicResearchRouteImport.update({
+  id: '/research',
+  path: '/research',
+  getParentRoute: () => PublicRoute,
+} as any)
+const PublicMarketingRoute = PublicMarketingRouteImport.update({
+  id: '/marketing',
+  path: '/marketing',
+  getParentRoute: () => PublicRoute,
+} as any)
+const PublicInvestorsRoute = PublicInvestorsRouteImport.update({
+  id: '/investors',
+  path: '/investors',
+  getParentRoute: () => PublicRoute,
+} as any)
+const PublicDocsRoute = PublicDocsRouteImport.update({
+  id: '/docs',
+  path: '/docs',
+  getParentRoute: () => PublicRoute,
+} as any)
 const PublicDocsIndexRoute = PublicDocsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -155,156 +162,165 @@ const PublicDocsCategoryArticleRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/app': typeof AppRouteWithChildren
   '/demo': typeof DemoRouteWithChildren
   '/sign-in': typeof SignInRoute
   '/subscribe': typeof SubscribeRoute
-  '/analytics': typeof AppAnalyticsRoute
-  '/history': typeof AppHistoryRoute
-  '/map': typeof AppMapRoute
-  '/onboarding': typeof AppOnboardingRoute
-  '/settings': typeof AppSettingsRoute
-  '/upgrade': typeof AppUpgradeRoute
   '/docs': typeof PublicDocsRouteWithChildren
   '/investors': typeof PublicInvestorsRoute
   '/marketing': typeof PublicMarketingRoute
   '/research': typeof PublicResearchRoute
   '/technology': typeof PublicTechnologyRoute
+  '/app/analytics': typeof AppAnalyticsRoute
+  '/app/history': typeof AppHistoryRoute
+  '/app/map': typeof AppMapRoute
+  '/app/onboarding': typeof AppOnboardingRoute
+  '/app/settings': typeof AppSettingsRoute
+  '/app/upgrade': typeof AppUpgradeRoute
   '/demo/analytics': typeof DemoAnalyticsRoute
   '/demo/history': typeof DemoHistoryRoute
   '/demo/settings': typeof DemoSettingsRoute
-  '/': typeof AppIndexRoute
+  '/app/': typeof AppIndexRoute
   '/demo/': typeof DemoIndexRoute
-  '/paddocks/$id': typeof AppPaddocksIdRoute
+  '/app/paddocks/$id': typeof AppPaddocksIdRoute
   '/docs/': typeof PublicDocsIndexRoute
   '/docs/$category/$article': typeof PublicDocsCategoryArticleRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/sign-in': typeof SignInRoute
   '/subscribe': typeof SubscribeRoute
-  '/analytics': typeof AppAnalyticsRoute
-  '/history': typeof AppHistoryRoute
-  '/map': typeof AppMapRoute
-  '/onboarding': typeof AppOnboardingRoute
-  '/settings': typeof AppSettingsRoute
-  '/upgrade': typeof AppUpgradeRoute
   '/investors': typeof PublicInvestorsRoute
   '/marketing': typeof PublicMarketingRoute
   '/research': typeof PublicResearchRoute
   '/technology': typeof PublicTechnologyRoute
+  '/app/analytics': typeof AppAnalyticsRoute
+  '/app/history': typeof AppHistoryRoute
+  '/app/map': typeof AppMapRoute
+  '/app/onboarding': typeof AppOnboardingRoute
+  '/app/settings': typeof AppSettingsRoute
+  '/app/upgrade': typeof AppUpgradeRoute
   '/demo/analytics': typeof DemoAnalyticsRoute
   '/demo/history': typeof DemoHistoryRoute
   '/demo/settings': typeof DemoSettingsRoute
-  '/': typeof AppIndexRoute
+  '/app': typeof AppIndexRoute
   '/demo': typeof DemoIndexRoute
-  '/paddocks/$id': typeof AppPaddocksIdRoute
+  '/app/paddocks/$id': typeof AppPaddocksIdRoute
   '/docs': typeof PublicDocsIndexRoute
   '/docs/$category/$article': typeof PublicDocsCategoryArticleRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/_app': typeof AppRouteWithChildren
+  '/': typeof IndexRoute
   '/_public': typeof PublicRouteWithChildren
+  '/app': typeof AppRouteWithChildren
   '/demo': typeof DemoRouteWithChildren
   '/sign-in': typeof SignInRoute
   '/subscribe': typeof SubscribeRoute
-  '/_app/analytics': typeof AppAnalyticsRoute
-  '/_app/history': typeof AppHistoryRoute
-  '/_app/map': typeof AppMapRoute
-  '/_app/onboarding': typeof AppOnboardingRoute
-  '/_app/settings': typeof AppSettingsRoute
-  '/_app/upgrade': typeof AppUpgradeRoute
   '/_public/docs': typeof PublicDocsRouteWithChildren
   '/_public/investors': typeof PublicInvestorsRoute
   '/_public/marketing': typeof PublicMarketingRoute
   '/_public/research': typeof PublicResearchRoute
   '/_public/technology': typeof PublicTechnologyRoute
+  '/app/analytics': typeof AppAnalyticsRoute
+  '/app/history': typeof AppHistoryRoute
+  '/app/map': typeof AppMapRoute
+  '/app/onboarding': typeof AppOnboardingRoute
+  '/app/settings': typeof AppSettingsRoute
+  '/app/upgrade': typeof AppUpgradeRoute
   '/demo/analytics': typeof DemoAnalyticsRoute
   '/demo/history': typeof DemoHistoryRoute
   '/demo/settings': typeof DemoSettingsRoute
-  '/_app/': typeof AppIndexRoute
+  '/app/': typeof AppIndexRoute
   '/demo/': typeof DemoIndexRoute
-  '/_app/paddocks/$id': typeof AppPaddocksIdRoute
+  '/app/paddocks/$id': typeof AppPaddocksIdRoute
   '/_public/docs/': typeof PublicDocsIndexRoute
   '/_public/docs/$category/$article': typeof PublicDocsCategoryArticleRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
+    | '/app'
     | '/demo'
     | '/sign-in'
     | '/subscribe'
-    | '/analytics'
-    | '/history'
-    | '/map'
-    | '/onboarding'
-    | '/settings'
-    | '/upgrade'
     | '/docs'
     | '/investors'
     | '/marketing'
     | '/research'
     | '/technology'
+    | '/app/analytics'
+    | '/app/history'
+    | '/app/map'
+    | '/app/onboarding'
+    | '/app/settings'
+    | '/app/upgrade'
     | '/demo/analytics'
     | '/demo/history'
     | '/demo/settings'
-    | '/'
+    | '/app/'
     | '/demo/'
-    | '/paddocks/$id'
+    | '/app/paddocks/$id'
     | '/docs/'
     | '/docs/$category/$article'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
     | '/sign-in'
     | '/subscribe'
-    | '/analytics'
-    | '/history'
-    | '/map'
-    | '/onboarding'
-    | '/settings'
-    | '/upgrade'
     | '/investors'
     | '/marketing'
     | '/research'
     | '/technology'
+    | '/app/analytics'
+    | '/app/history'
+    | '/app/map'
+    | '/app/onboarding'
+    | '/app/settings'
+    | '/app/upgrade'
     | '/demo/analytics'
     | '/demo/history'
     | '/demo/settings'
-    | '/'
+    | '/app'
     | '/demo'
-    | '/paddocks/$id'
+    | '/app/paddocks/$id'
     | '/docs'
     | '/docs/$category/$article'
   id:
     | '__root__'
-    | '/_app'
+    | '/'
     | '/_public'
+    | '/app'
     | '/demo'
     | '/sign-in'
     | '/subscribe'
-    | '/_app/analytics'
-    | '/_app/history'
-    | '/_app/map'
-    | '/_app/onboarding'
-    | '/_app/settings'
-    | '/_app/upgrade'
     | '/_public/docs'
     | '/_public/investors'
     | '/_public/marketing'
     | '/_public/research'
     | '/_public/technology'
+    | '/app/analytics'
+    | '/app/history'
+    | '/app/map'
+    | '/app/onboarding'
+    | '/app/settings'
+    | '/app/upgrade'
     | '/demo/analytics'
     | '/demo/history'
     | '/demo/settings'
-    | '/_app/'
+    | '/app/'
     | '/demo/'
-    | '/_app/paddocks/$id'
+    | '/app/paddocks/$id'
     | '/_public/docs/'
     | '/_public/docs/$category/$article'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  AppRoute: typeof AppRouteWithChildren
+  IndexRoute: typeof IndexRoute
   PublicRoute: typeof PublicRouteWithChildren
+  AppRoute: typeof AppRouteWithChildren
   DemoRoute: typeof DemoRouteWithChildren
   SignInRoute: typeof SignInRoute
   SubscribeRoute: typeof SubscribeRoute
@@ -333,6 +349,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DemoRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/app': {
+      id: '/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AppRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_public': {
       id: '/_public'
       path: ''
@@ -340,11 +363,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app': {
-      id: '/_app'
-      path: ''
-      fullPath: ''
-      preLoaderRoute: typeof AppRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/demo/': {
@@ -354,10 +377,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DemoIndexRouteImport
       parentRoute: typeof DemoRoute
     }
-    '/_app/': {
-      id: '/_app/'
+    '/app/': {
+      id: '/app/'
       path: '/'
-      fullPath: '/'
+      fullPath: '/app/'
       preLoaderRoute: typeof AppIndexRouteImport
       parentRoute: typeof AppRoute
     }
@@ -381,6 +404,48 @@ declare module '@tanstack/react-router' {
       fullPath: '/demo/analytics'
       preLoaderRoute: typeof DemoAnalyticsRouteImport
       parentRoute: typeof DemoRoute
+    }
+    '/app/upgrade': {
+      id: '/app/upgrade'
+      path: '/upgrade'
+      fullPath: '/app/upgrade'
+      preLoaderRoute: typeof AppUpgradeRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/settings': {
+      id: '/app/settings'
+      path: '/settings'
+      fullPath: '/app/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/onboarding': {
+      id: '/app/onboarding'
+      path: '/onboarding'
+      fullPath: '/app/onboarding'
+      preLoaderRoute: typeof AppOnboardingRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/map': {
+      id: '/app/map'
+      path: '/map'
+      fullPath: '/app/map'
+      preLoaderRoute: typeof AppMapRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/history': {
+      id: '/app/history'
+      path: '/history'
+      fullPath: '/app/history'
+      preLoaderRoute: typeof AppHistoryRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/analytics': {
+      id: '/app/analytics'
+      path: '/analytics'
+      fullPath: '/app/analytics'
+      preLoaderRoute: typeof AppAnalyticsRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_public/technology': {
       id: '/_public/technology'
@@ -417,48 +482,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicDocsRouteImport
       parentRoute: typeof PublicRoute
     }
-    '/_app/upgrade': {
-      id: '/_app/upgrade'
-      path: '/upgrade'
-      fullPath: '/upgrade'
-      preLoaderRoute: typeof AppUpgradeRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/settings': {
-      id: '/_app/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof AppSettingsRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/onboarding': {
-      id: '/_app/onboarding'
-      path: '/onboarding'
-      fullPath: '/onboarding'
-      preLoaderRoute: typeof AppOnboardingRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/map': {
-      id: '/_app/map'
-      path: '/map'
-      fullPath: '/map'
-      preLoaderRoute: typeof AppMapRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/history': {
-      id: '/_app/history'
-      path: '/history'
-      fullPath: '/history'
-      preLoaderRoute: typeof AppHistoryRouteImport
-      parentRoute: typeof AppRoute
-    }
-    '/_app/analytics': {
-      id: '/_app/analytics'
-      path: '/analytics'
-      fullPath: '/analytics'
-      preLoaderRoute: typeof AppAnalyticsRouteImport
-      parentRoute: typeof AppRoute
-    }
     '/_public/docs/': {
       id: '/_public/docs/'
       path: '/'
@@ -466,10 +489,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PublicDocsIndexRouteImport
       parentRoute: typeof PublicDocsRoute
     }
-    '/_app/paddocks/$id': {
-      id: '/_app/paddocks/$id'
+    '/app/paddocks/$id': {
+      id: '/app/paddocks/$id'
       path: '/paddocks/$id'
-      fullPath: '/paddocks/$id'
+      fullPath: '/app/paddocks/$id'
       preLoaderRoute: typeof AppPaddocksIdRouteImport
       parentRoute: typeof AppRoute
     }
@@ -482,30 +505,6 @@ declare module '@tanstack/react-router' {
     }
   }
 }
-
-interface AppRouteChildren {
-  AppAnalyticsRoute: typeof AppAnalyticsRoute
-  AppHistoryRoute: typeof AppHistoryRoute
-  AppMapRoute: typeof AppMapRoute
-  AppOnboardingRoute: typeof AppOnboardingRoute
-  AppSettingsRoute: typeof AppSettingsRoute
-  AppUpgradeRoute: typeof AppUpgradeRoute
-  AppIndexRoute: typeof AppIndexRoute
-  AppPaddocksIdRoute: typeof AppPaddocksIdRoute
-}
-
-const AppRouteChildren: AppRouteChildren = {
-  AppAnalyticsRoute: AppAnalyticsRoute,
-  AppHistoryRoute: AppHistoryRoute,
-  AppMapRoute: AppMapRoute,
-  AppOnboardingRoute: AppOnboardingRoute,
-  AppSettingsRoute: AppSettingsRoute,
-  AppUpgradeRoute: AppUpgradeRoute,
-  AppIndexRoute: AppIndexRoute,
-  AppPaddocksIdRoute: AppPaddocksIdRoute,
-}
-
-const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
 interface PublicDocsRouteChildren {
   PublicDocsIndexRoute: typeof PublicDocsIndexRoute
@@ -540,6 +539,30 @@ const PublicRouteChildren: PublicRouteChildren = {
 const PublicRouteWithChildren =
   PublicRoute._addFileChildren(PublicRouteChildren)
 
+interface AppRouteChildren {
+  AppAnalyticsRoute: typeof AppAnalyticsRoute
+  AppHistoryRoute: typeof AppHistoryRoute
+  AppMapRoute: typeof AppMapRoute
+  AppOnboardingRoute: typeof AppOnboardingRoute
+  AppSettingsRoute: typeof AppSettingsRoute
+  AppUpgradeRoute: typeof AppUpgradeRoute
+  AppIndexRoute: typeof AppIndexRoute
+  AppPaddocksIdRoute: typeof AppPaddocksIdRoute
+}
+
+const AppRouteChildren: AppRouteChildren = {
+  AppAnalyticsRoute: AppAnalyticsRoute,
+  AppHistoryRoute: AppHistoryRoute,
+  AppMapRoute: AppMapRoute,
+  AppOnboardingRoute: AppOnboardingRoute,
+  AppSettingsRoute: AppSettingsRoute,
+  AppUpgradeRoute: AppUpgradeRoute,
+  AppIndexRoute: AppIndexRoute,
+  AppPaddocksIdRoute: AppPaddocksIdRoute,
+}
+
+const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
+
 interface DemoRouteChildren {
   DemoAnalyticsRoute: typeof DemoAnalyticsRoute
   DemoHistoryRoute: typeof DemoHistoryRoute
@@ -557,8 +580,9 @@ const DemoRouteChildren: DemoRouteChildren = {
 const DemoRouteWithChildren = DemoRoute._addFileChildren(DemoRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-  AppRoute: AppRouteWithChildren,
+  IndexRoute: IndexRoute,
   PublicRoute: PublicRouteWithChildren,
+  AppRoute: AppRouteWithChildren,
   DemoRoute: DemoRouteWithChildren,
   SignInRoute: SignInRoute,
   SubscribeRoute: SubscribeRoute,

--- a/app/src/routes/_public/investors.tsx
+++ b/app/src/routes/_public/investors.tsx
@@ -398,7 +398,7 @@ function InvestorsPage() {
               </Link>
 
               <Link
-                to="/onboarding"
+                to="/sign-in"
                 className="bg-[#1a2429]/80 backdrop-blur-sm border border-[#075056]/40 rounded-lg shadow-lg shadow-black/20 p-4 hover:border-[#075056] transition-colors block"
               >
                 <h3 className="text-sm font-semibold text-[#FDF6E3] mb-1">Try It Free</h3>

--- a/app/src/routes/app/analytics.tsx
+++ b/app/src/routes/app/analytics.tsx
@@ -14,7 +14,7 @@ import {
   AIPartnershipChart,
 } from '@/components/analytics'
 
-export const Route = createFileRoute('/_app/analytics')({
+export const Route = createFileRoute('/app/analytics')({
   component: AnalyticsPage,
 })
 

--- a/app/src/routes/app/history.tsx
+++ b/app/src/routes/app/history.tsx
@@ -13,7 +13,7 @@ import { LoadingSpinner } from '@/components/ui/loading'
 import { ErrorState } from '@/components/ui/error'
 import type { Id } from '../../../convex/_generated/dataModel'
 
-export const Route = createFileRoute('/_app/history')({
+export const Route = createFileRoute('/app/history')({
   component: HistoryPage,
 })
 

--- a/app/src/routes/app/index.tsx
+++ b/app/src/routes/app/index.tsx
@@ -61,7 +61,7 @@ interface EditDrawerState {
 function GISRoute() {
   console.log('[_app/index] Rendering GISRoute')
   const navigate = useNavigate()
-  const search = useSearch({ from: '/_app/' })
+  const search = useSearch({ from: '/app/' })
   const { activeFarmId, activeFarm, isLoading } = useFarmContext()
   const { briefOpen, setBriefOpen } = useBriefPanel()
   const hasFarmBoundary = activeFarm?.geometry != null
@@ -180,7 +180,7 @@ function GISRoute() {
         })
 
         // Navigate to paddock editing step
-        navigate({ to: '/', search: { editPaddock: 'true' } })
+        navigate({ to: '/app', search: { editPaddock: 'true' } })
       } catch (err) {
         console.error('[Onboarding Save Effect] Error saving paddock:', err)
         toast.error('Failed to save paddock')
@@ -197,7 +197,7 @@ function GISRoute() {
     boundaryCompleteRef.current = true
     // Stop the drawing mode and remove the query param
     cancelDraw()
-    navigate({ to: '/', search: {} })
+    navigate({ to: '/app', search: {} })
   }, [cancelDraw, navigate])
 
   const handleBoundarySaved = useCallback(async (_geometry: Feature<Polygon>) => {
@@ -282,7 +282,7 @@ function GISRoute() {
     // Mark that we're intentionally canceling to prevent effect re-triggering
     boundaryCompleteRef.current = true
     cancelDraw()
-    navigate({ to: '/', search: {} })
+    navigate({ to: '/app', search: {} })
   }, [cancelDraw, navigate])
   const [selectedNoGrazeZone, setSelectedNoGrazeZone] = useState<NoGrazeZone | null>(null)
   const [selectedWaterSource, setSelectedWaterSource] = useState<WaterSource | null>(null)
@@ -726,7 +726,7 @@ function GISRoute() {
           onComplete={() => {
             // Save any pending changes and proceed to animal location
             saveChanges().then(() => {
-              navigate({ to: '/', search: { setAnimalLocation: 'true' } })
+              navigate({ to: '/app', search: { setAnimalLocation: 'true' } })
             })
           }}
         />
@@ -739,7 +739,7 @@ function GISRoute() {
           map={mapInstance}
           onComplete={() => {
             // Clear the query param
-            navigate({ to: '/', search: {} })
+            navigate({ to: '/app', search: {} })
             // Trigger tutorial if not completed
             if (!getTutorialCompleted()) {
               startTutorial()
@@ -749,7 +749,7 @@ function GISRoute() {
           }}
           onSkip={() => {
             // Allow skipping - clear the param
-            navigate({ to: '/', search: {} })
+            navigate({ to: '/app', search: {} })
             // Trigger tutorial if not completed
             if (!getTutorialCompleted()) {
               startTutorial()
@@ -999,7 +999,7 @@ function GISRoute() {
   )
 }
 
-export const Route = createFileRoute('/_app/')({
+export const Route = createFileRoute('/app/')({
   component: GISRoute,
   validateSearch: searchSchema,
 })

--- a/app/src/routes/app/map.tsx
+++ b/app/src/routes/app/map.tsx
@@ -3,9 +3,9 @@ import { createFileRoute, Navigate } from '@tanstack/react-router'
 // Map functionality is now integrated into the main GIS view at /
 // This route redirects for backwards compatibility
 function MapRedirect() {
-  return <Navigate to="/" replace />
+  return <Navigate to="/app" replace />
 }
 
-export const Route = createFileRoute('/_app/map')({
+export const Route = createFileRoute('/app/map')({
   component: MapRedirect,
 })

--- a/app/src/routes/app/onboarding.tsx
+++ b/app/src/routes/app/onboarding.tsx
@@ -13,7 +13,7 @@ import {
 import type { LivestockData, GeoFenceData } from '@/components/onboarding'
 import { useAppAuth } from '@/lib/auth'
 
-export const Route = createFileRoute('/_app/onboarding')({
+export const Route = createFileRoute('/app/onboarding')({
   component: OnboardingPage,
 })
 
@@ -74,7 +74,7 @@ function DevOnboarding({ organizationId }: { organizationId: string | null }) {
 
   const handleDevSkip = () => {
     sessionStorage.removeItem('onboardingInProgress')
-    navigate({ to: '/' })
+    navigate({ to: '/app' })
   }
 
   const handleFarmSetup = async (data: FarmData) => {
@@ -151,7 +151,7 @@ function DevOnboarding({ organizationId }: { organizationId: string | null }) {
 
     if (!createdFarmId) {
       // If no farm was created yet, just navigate to map setup
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
       return
     }
 
@@ -187,11 +187,11 @@ function DevOnboarding({ organizationId }: { organizationId: string | null }) {
       }
 
       // Navigate to map setup - tutorial will be triggered after animal location step
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
     } catch (err) {
       console.error('Error saving onboarding data:', err)
       // Continue to map setup even if saving fails
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
     }
   }
 
@@ -385,7 +385,7 @@ function ClerkOnboarding() {
 
     if (!createdFarmId) {
       // If no farm was created yet, just navigate to map setup
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
       return
     }
 
@@ -421,11 +421,11 @@ function ClerkOnboarding() {
       }
 
       // Navigate to map setup - tutorial will be triggered after animal location step
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
     } catch (err) {
       console.error('Error saving onboarding data:', err)
       // Continue to map setup even if saving fails
-      navigate({ to: '/', search: { onboarded: 'true', editBoundary: 'true' } })
+      navigate({ to: '/app', search: { onboarded: 'true', editBoundary: 'true' } })
     }
   }
 

--- a/app/src/routes/app/paddocks/$id.tsx
+++ b/app/src/routes/app/paddocks/$id.tsx
@@ -14,7 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Droplets, Timer, Grid3X3 } from 'lucide-react'
 import { useGeometry } from '@/lib/geometry'
 
-export const Route = createFileRoute('/_app/paddocks/$id')({
+export const Route = createFileRoute('/app/paddocks/$id')({
   component: PaddockDetailPage,
 })
 

--- a/app/src/routes/app/settings.tsx
+++ b/app/src/routes/app/settings.tsx
@@ -16,7 +16,7 @@ import { useFarmSettings } from '@/lib/convex/useFarmSettings'
 import { useFarmContext } from '@/lib/farm'
 import type { FarmSettings } from '@/lib/types'
 
-export const Route = createFileRoute('/_app/settings')({
+export const Route = createFileRoute('/app/settings')({
   component: SettingsPage,
 })
 

--- a/app/src/routes/app/upgrade.tsx
+++ b/app/src/routes/app/upgrade.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { SubscriptionTier } from '@/lib/hooks/useSubscription'
 
-export const Route = createFileRoute('/_app/upgrade')({
+export const Route = createFileRoute('/app/upgrade')({
   component: UpgradePage,
 })
 
@@ -85,7 +85,7 @@ function UpgradePage() {
     <div className="h-full overflow-auto">
       <div className="p-4 max-w-6xl mx-auto">
         <Link
-          to="/settings"
+          to="/app/settings"
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4"
         >
           <ArrowLeft className="h-4 w-4" />

--- a/app/src/routes/demo/analytics.tsx
+++ b/app/src/routes/demo/analytics.tsx
@@ -178,7 +178,7 @@ function DemoAnalyticsPage() {
                 Sign up to track NDVI trends, paddock recovery, and AI recommendation accuracy for your farm.
               </p>
             </div>
-            <Link to="/onboarding">
+            <Link to="/sign-in">
               <Button>
                 <UserPlus className="h-4 w-4 mr-2" />
                 Create Account

--- a/app/src/routes/demo/history.tsx
+++ b/app/src/routes/demo/history.tsx
@@ -141,7 +141,7 @@ function DemoHistoryPage() {
                 Sign up to see AI recommendations for your actual paddocks with real satellite data.
               </p>
             </div>
-            <Link to="/onboarding">
+            <Link to="/sign-in">
               <Button>
                 <UserPlus className="h-4 w-4 mr-2" />
                 Create Account

--- a/app/src/routes/demo/settings.tsx
+++ b/app/src/routes/demo/settings.tsx
@@ -69,7 +69,7 @@ function DemoSettingsPage() {
                 Sign up to save your settings and get personalized grazing recommendations.
               </p>
             </div>
-            <Link to="/onboarding">
+            <Link to="/sign-in">
               <Button>
                 <UserPlus className="h-4 w-4 mr-2" />
                 Create Account

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,0 +1,77 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  MarketingHeader,
+  HeroSection,
+  ProductShowcase,
+  HowItWorks,
+  VisionRoadmap,
+  OpenPhilosophy,
+  VirtualFencingDifferentiator,
+  CTASection,
+  Footer,
+  BetaValueProp,
+} from '@/components/marketing'
+
+function LandingPage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#1a2429] text-[#FDF6E3]">
+      <MarketingHeader />
+      <HeroSection />
+      <BetaValueProp />
+
+      {/* Product Showcase: Daily Brief */}
+      <ProductShowcase
+        title="Your Morning Decision, Made Simple"
+        description="AI analyzes satellite data overnight and delivers a recommended grazing plan with confidence scores and reasoning."
+        bullets={[
+          'Wake up to a clear recommendation for today',
+          'Understand the "why" behind each suggestion',
+          'Override with one tap when conditions change',
+        ]}
+        screenshotSrc="/marketing/daily-brief.png"
+        screenshotAlt="Daily Brief panel showing AI-recommended paddock with confidence score and reasoning"
+        badge="Available now"
+      />
+
+      {/* Product Showcase: Satellite Intelligence */}
+      <ProductShowcase
+        title="See What's Invisible from the Ground"
+        description="NDVI heatmaps reveal vegetation health across your entire operation. Historical patterns show recovery trends you can't observe manually."
+        bullets={[
+          'Color-coded vegetation health at a glance',
+          'Track recovery patterns over time',
+          'Identify problem areas before they spread',
+        ]}
+        screenshotSrc="/marketing/ndvi-map.png"
+        screenshotAlt="Map showing NDVI vegetation health overlay with paddock sections highlighted"
+        reverse
+        badge="Available now"
+      />
+
+      {/* Product Showcase: Analytics Dashboard */}
+      <ProductShowcase
+        title="Track Recovery, Optimize Timing"
+        description="Monitor rest periods, recovery rates, and AI approval trends. Identify which paddocks are thriving and which need attention."
+        bullets={[
+          'Real-time paddock status tracking',
+          'Historical grazing patterns and recovery',
+          'Data-driven insights for better rotation',
+        ]}
+        screenshotSrc="/marketing/paddock-status.png"
+        screenshotAlt="Analytics dashboard showing paddock metrics and recovery tracking"
+        badge="Available now"
+      />
+
+      <HowItWorks />
+      <VirtualFencingDifferentiator />
+      <VisionRoadmap />
+      <OpenPhilosophy />
+      <CTASection />
+      <Footer />
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/')({
+  component: LandingPage,
+})

--- a/app/src/routes/sign-in.tsx
+++ b/app/src/routes/sign-in.tsx
@@ -17,9 +17,15 @@ function SignInPage() {
 
   useEffect(() => {
     if (isSignedIn || isDevAuth) {
-      navigate({ to: redirectTo || '/' })
+      navigate({ to: redirectTo || '/app' })
     }
   }, [isSignedIn, isDevAuth, redirectTo, navigate])
+
+  // In dev mode, don't render Clerk's SignIn component (no ClerkProvider)
+  // The useEffect above will redirect to /app
+  if (isDevAuth) {
+    return null
+  }
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background p-6">
@@ -35,7 +41,7 @@ function SignInPage() {
 
       <SignIn
         routing="hash"
-        forceRedirectUrl={redirectTo || '/'}
+        forceRedirectUrl={redirectTo || '/app'}
         appearance={clerkAppearance}
       />
     </div>


### PR DESCRIPTION
## Summary
- Rename route directory from `_app/` to `app/` for cleaner URLs
- Add `hasPlan()` and `isPlanLoaded` to auth context for subscription checks
- Update all component imports to use new route paths
- Add `VITE_PAYWALL_DISABLED` env var documentation

## Test plan
- [ ] Verify all routes load correctly under `/app/*`
- [ ] Check auth context provides plan checking functions
- [ ] Confirm dev mode bypasses subscription checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)